### PR TITLE
Add "OTHER" to list of valid licenses

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var licenses = []
+var licenses = ['OTHER']
   .concat(require('spdx-license-ids'))
   .concat(require('spdx-license-ids/deprecated'))
 var exceptions = require('spdx-exceptions')


### PR DESCRIPTION
Clearly Defined accepts "OTHER" as a valid license, but it is not SPDX valid. We must include it as to fix the SPDX validation bug in Clearly Defined where declaring "OTHER" throws an error since it's not currently included in the list of valid licenses.