### PR TITLE
Update spdx-license-ids from 3.0.2 to 3.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1809,9 +1809,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "spdx-exceptions": "^2.1.0",
-    "spdx-license-ids": "^3.0.0"
+    "spdx-license-ids": "^3.0.7"
   },
   "devDependencies": {
     "defence-cli": "^2.0.1",


### PR DESCRIPTION
There is an license spdx valiation error for PSF-2.0 because spdx-license-ids@3.0.2
doesn't include PSF-2.0