### PR TITLE
Update spdx-license-ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1809,9 +1809,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "spdx-exceptions": "^2.1.0",
-    "spdx-license-ids": "^3.0.7"
+    "spdx-license-ids": "^3.0.12"
   },
   "devDependencies": {
     "defence-cli": "^2.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -83,3 +83,9 @@ it('parses `AND`, `OR` and `WITH` with the correct precedence', function () {
     }
   )
 })
+
+it('should parse BSD-3-Clause-Modification', function () {
+  assert.deepEqual(
+    p('BSD-3-Clause-Modification'),
+    {license: 'BSD-3-Clause-Modification'})
+})


### PR DESCRIPTION
Update spdx-license-ids to the same version as in https://github.com/clearlydefined/spdx/pull/27.  
Add a unit test that this upgrade addresses.

Task: https://github.com/clearlydefined/service/issues/846#issuecomment-1411332067